### PR TITLE
Update webmention content sanitizer

### DIFF
--- a/src/filters/webmentions-filter.js
+++ b/src/filters/webmentions-filter.js
@@ -16,10 +16,8 @@ const webmentionsFilter = function(webmentions, url) {
   };
 
   const sanitize = entry => {
-    const {content} = entry;
-    if (content['content-type'] === 'text/html') {
-      content.value = sanitizeHTML(content.value);
-    }
+    const { html, text } = entry.content;
+    entry.content.value = html ? sanitizeHTML(html) : sanitizeHTML(text);
     return entry;
   };
 


### PR DESCRIPTION
Just a heads up - @zachleat pointed out to me that the content-type property is not always present here, he even had a case where the plain text content contained a script tag. Better to sanitize everything to be safe.